### PR TITLE
Add missing pthread.h for wtable.c

### DIFF
--- a/libfiu/wtable.c
+++ b/libfiu/wtable.c
@@ -22,6 +22,7 @@
 #include <stdlib.h>		/* for malloc() */
 #include <string.h>		/* for memcpy()/memcmp() */
 #include <stdio.h>		/* snprintf() */
+#include <pthread.h>	/* pthread_* */
 
 #include "wtable.h"
 


### PR DESCRIPTION
Cc: @hanfei1991

_P.S. No need to upstream the change since the initial patch had not been backported (https://github.com/hanfei1991/libfiu/commit/7ae4328050ccad8867a05a37af941886f717b6fc), also not sure that I understand how the initial patch fixes the build._