### PR TITLE
Introduce a fastpath when no fail points are used

### DIFF
--- a/libfiu/fiu.c
+++ b/libfiu/fiu.c
@@ -142,6 +142,9 @@ __thread int rec_count = 0;
 /* Used to keep the last failinfo via TLS */
 static pthread_key_t last_failinfo_key;
 
+/* Used to shortcut checks in production */
+atomic_int has_any_failpoint_been_registered = 0;
+
 
 /*
  * Miscelaneous internal functions
@@ -416,6 +419,7 @@ int fiu_enable(const char *name, int failnum, void *failinfo,
 	if (pf == NULL)
 		return -1;
 
+    has_any_failpoint_been_registered = 1;
 	return insert_pf(pf);
 #if defined(__has_feature)
 # if __has_feature(address_sanitizer)

--- a/libfiu/fiu.h
+++ b/libfiu/fiu.h
@@ -19,6 +19,8 @@
 extern "C" {
 #endif
 
+#include <stdatomic.h>
+
 
 /** Initializes the library.
  *
@@ -62,12 +64,21 @@ int fiu_fail(const char *name);
  */
 void *fiu_failinfo(void);
 
+/// In production it's extremely unusual to use failpoints, but checking them has a cost (function call, global mutex lock, hash table lookup...)
+/// We've introduced this atomic variable to avoid that cost when no failpoints have been registered in the lifetime of the program
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc11-extensions"
+extern atomic_int has_any_failpoint_been_registered;
+#pragma clang diagnostic pop
+
 /** Performs the given action when the given point of failure fails. Mostly
  * used in the following macros. */
 #define fiu_do_on(name, action) \
         do { \
-                if (fiu_fail(name)) { \
-                        action; \
+                if (atomic_load_explicit(&has_any_failpoint_been_registered, memory_order_relaxed)) [[unlikely]] { \
+                        if (fiu_fail(name)) [[unlikely]] { \
+                                action; \
+                        } \
                 } \
         } while (0)
 


### PR DESCRIPTION
In production it's extremely unusual to use failpoints, but checking them has a cost (function call, global mutex lock, hash table lookup...). Let's introduce an atomic variable to avoid that cost when no failpoints have been registered in the lifetime of the program


cc @rschu1ze @hanfei1991 